### PR TITLE
Fix Property 'media_url' does not exist on type pottery_stages

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -53,7 +53,6 @@ const Dashboard = () => {
             stagesData.forEach(stage => {
               formattedStages[stage.stage_type as StageType] = {
                 weight: stage.weight,
-                media: stage.media_url,
                 dimension: stage.dimension,
                 description: stage.description,
                 decoration: stage.decoration

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -52,7 +52,6 @@ const Search = () => {
             stagesData.forEach(stage => {
               formattedStages[stage.stage_type as StageType] = {
                 weight: stage.weight,
-                media: stage.media_url,
                 dimension: stage.dimension,
                 description: stage.description,
                 decoration: stage.decoration


### PR DESCRIPTION
src/pages/Dashboard.tsx(56,30): error TS2339: Property 'media_url' does not exist on type '{ created_at: string; decoration: string; description: string; dimension: string; id: string; pottery_id: string; stage_type: string; updated_at: string; weight: number; }'.
src/pages/Search.tsx(55,30): error TS2339: Property 'media_url' does not exist on type '{ created_at: string; decoration: string; description: string; dimension: string; id: string; pottery_id: string; stage_type: string; updated_at: string; weight: number; }'.

Error after removing media_url column from pottery_stages