### PR TITLE
Fix 404 route after deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
Attempt to fix weird behaviour for google sign in

Existing behaviours
1. accessing through domain provided by vercel --> log in successfully and showing custom-domain/dashboard
2. accessing locally (localhost:8080) --> log in successfully and showing custom-domain/dashboard
3. accessing through custom domain --> not sure if log in is successful cuz the custom-domain/dashboard shows 404 not found thrown by vercel